### PR TITLE
Monkey patch the gem_publisher execute method in jruby

### DIFF
--- a/lib/logstash/devutils/rake/publish.rake
+++ b/lib/logstash/devutils/rake/publish.rake
@@ -1,5 +1,23 @@
 require "gem_publisher"
 
+# gem_publisher uses Open3.capture3 to call git binary
+# this does not work on jruby. Open3.popen3 works
+if RUBY_PLATFORM == "java"
+  module GemPublisher
+    class CliFacade
+      def execute(*arguments)
+        cmd = Shellwords.join(arguments)
+        puts cmd
+        Open3.popen3(cmd) do |_i, stdout, stderr, thr|
+          output = [stderr.read, stdout.read].join.strip
+          raise Error, output if thr.value.exitstatus > 0
+          return output
+        end
+      end
+    end
+  end
+end
+
 desc "Publish gem to RubyGems.org"
 task :publish_gem do |t|
   gem_file = Dir.glob(File.expand_path('../*.gemspec',File.dirname(__FILE__))).first


### PR DESCRIPTION
This is due to a bug in JRuby's Open3.capture3 method.
Using Open3.popen3 solves the problem
