### PR TITLE
Adding an option to exclude all the tests tagged as integration

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -45,6 +45,6 @@ end
 
 RSpec.configure do |config|
   config.extend LogStashHelper
-  config.filter_run_excluding :redis => true, :socket => true, :performance => true, :elasticsearch => true, :elasticsearch_secure => true, :broken => true, :export_cypher => true
+  config.filter_run_excluding :redis => true, :socket => true, :performance => true, :elasticsearch => true, :elasticsearch_secure => true, :broken => true, :export_cypher => true, :integration => true
 end
 


### PR DESCRIPTION
Since we can add multiple tags to a spec can we exclude a more generic tag? 
This will allow us to iterate on the plugins without updating this gem.

We could specify a test like this.

``` ruby
describe LogStash::Output::Elasticsearch,  :integration => true, :docker => "elasticsearch"  do
end
```

And the two tags could be use to launch the appropriate docker? See ticket https://github.com/elasticsearch/logstash/issues/1737 for future work.
