### PR TITLE
Silence the logger when running the test

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -22,11 +22,9 @@ if RUBY_VERSION < "1.9.2"
   raise LoadError
 end
 
-$logger = LogStash::Logger.new(STDOUT)
 if ENV["TEST_DEBUG"]
+  $logger = LogStash::Logger.new(STDOUT)
   $logger.level = :debug
-else
-  $logger.level = :error
 end
 
 puts("Using Accessor#strict_set for specs")


### PR DESCRIPTION
When you were running the test, the logger was writing `error` level log events to stdout.
By default silence the logger when running the test. 
If you want to debug, you can set `ENV["TEST_DEBUG"]` to 1 before running the test to display `debug` level events.
