### PR TITLE
remove jar-dependencies dependency

### DIFF
--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.12"
+  spec.version = "0.0.13"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rspec", "~> 2.14.0" # MIT License
   spec.platform = "java"
-  spec.add_runtime_dependency "jar-dependencies" # MIT License
   spec.add_runtime_dependency "rake" # MIT License
   spec.add_runtime_dependency "gem_publisher" # MIT License
   spec.add_runtime_dependency "minitar" # GPL2|Ruby License


### PR DESCRIPTION
it is unused and causes conflict when doing first

    rake test:install-core

then

    rake artifact:tar

because in the fist task, jar-dependencies in devutils is resolved to the latest version but in the second task, the kafka plugins are pulled and depend on a specific earlier version of jar-dependencies and abort in conflict.