### PR TITLE
define LOGSTASH_HOME if undef

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -17,6 +17,10 @@ require "logstash/environment"
 require "logstash/devutils/rspec/logstash_helpers"
 require "insist"
 
+unless LogStash::Environment.const_defined?(:LOGSTASH_HOME)
+  LogStash::Environment::LOGSTASH_HOME = Dir.pwd
+end
+
 $TESTING = true
 if RUBY_VERSION < "1.9.2"
   $stderr.puts "Ruby 1.9.2 or later is required. (You are running: " + RUBY_VERSION + ")"


### PR DESCRIPTION
when running tests from a plugin's repository, LOGSTASH_HOME is not defined, so we detect that here and we can set it to either
1) the logstash-devutils root directory 
2) the Dir.pwd

This PR chose 2) but the "right answer" is not clear.

Addresses https://github.com/elastic/logstash/issues/3174 and https://github.com/elastic/logstash/issues/3175