### PR TITLE
Adding rpec helper `try`

### DIFF
--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -1,9 +1,17 @@
 require "logstash/agent"
 require "logstash/pipeline"
 require "logstash/event"
+require "stud/try"
+require "rspec/expectations"
 require "thread"
 
 module LogStashHelper
+  DEFAULT_NUMBER_OF_TRY = 5
+  DEFAULT_EXCEPTIONS_FOR_TRY = [RSpec::Expectations::ExpectationNotMetError]
+
+  def try(number_of_try = DEFAULT_NUMBER_OF_TRY, &block)
+    Stud.try(number_of_try.times, DEFAULT_EXCEPTIONS_FOR_TRY, &block)
+  end
 
   def config(configstr)
     let(:config) { configstr }

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   # own, and not relying on being required by the spec helper.
   # (some plugins does it, some use insist throw spec_helper)
   spec.add_runtime_dependency "insist", "1.0.0" # (Apache 2.0 license)
+  spec.add_runtime_dependency "kramdown"
+  spec.add_runtime_dependency "stud", " >= 0.0.20"
 end

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.14"
+  spec.version = "0.0.15"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"


### PR DESCRIPTION
This helper is based on `Stud.try`, it allow the expectation to be run
multiple times before actually failing.


Example:
```ruby
    context "bad test" do
      it "should be retried" do
          count = 0
          try do
            count += 1
            expect(2).to eq(4)
          end
      end

      # COUNT will be equal to 5
    end