### PR TITLE
add input plugin shared_example

### DIFF
--- a/lib/logstash/devutils/rspec/shared_examples.rb
+++ b/lib/logstash/devutils/rspec/shared_examples.rb
@@ -1,0 +1,21 @@
+require 'rspec/wait'
+
+RSpec.shared_examples "an interruptible input plugin" do
+  describe "#stop" do
+    let(:queue) { SizedQueue.new(20) }
+    subject { described_class.new(config) }
+    before(:each) { subject.register }
+
+    it "returns from run" do
+      consumer_thread = Thread.new(queue) { |queue| loop { queue.pop } }
+      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
+      # the run method is a long lived one, so it should still be running after "a bit"
+      sleep 0.5
+      expect(plugin_thread).to be_alive
+      # now let's actually stop the plugin
+      subject.do_stop
+      # why 3? 2 is not enough, 4 is too much..
+      wait(3).for { plugin_thread }.to_not be_alive
+    end
+  end
+end

--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -15,6 +15,7 @@ end
 require "logstash/logging"
 require "logstash/environment"
 require "logstash/devutils/rspec/logstash_helpers"
+require "logstash/devutils/rspec/shared_examples"
 require "insist"
 
 $TESTING = true

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/elasticsearch/logstash-devutils"
 
   spec.add_runtime_dependency "rspec", "~> 3.1.0" # MIT License
+  spec.add_runtime_dependency "rspec-wait" # MIT License
   spec.platform = "java"
   spec.add_runtime_dependency "rake" # MIT License
   spec.add_runtime_dependency "gem_publisher" # MIT License


### PR DESCRIPTION
This adds a shared example spec for all input plugins: a `plugin.stop` should abort the `plugin.run`

This PR is a requirement for testing the shutdown sequence proposed by https://github.com/elastic/logstash/pull/3812  (now elastic/logstash#3895)