### PR TITLE
Add to the spec exclude list a zeromq tag

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   config.include LogStashHelper
   config.extend LogStashHelper
 
-  exclude_tags = { :redis => true, :socket => true, :performance => true, :couchdb => true, :elasticsearch => true, :elasticsearch_secure => true, :export_cypher => true, :integration => true }
+  exclude_tags = { :zeromq => true, :redis => true, :socket => true, :performance => true, :couchdb => true, :elasticsearch => true, :elasticsearch_secure => true, :export_cypher => true, :integration => true }
 
   if LogStash::Environment.windows?
     exclude_tags[:unix] = true

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.15"
+  spec.version = "0.0.16"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"


### PR DESCRIPTION
Necessary to exclude the test for the zeromq plugins until they get properly refactored and could be unit tested properly.

Related to: https://github.com/logstash-plugins/logstash-input-zeromq/pull/8#issuecomment-141002004