### PR TITLE
ensure plugin specs run with abort_on_exception

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -17,6 +17,8 @@ require "logstash/environment"
 require "logstash/devutils/rspec/logstash_helpers"
 require "insist"
 
+Thread.abort_on_exception = true
+
 $TESTING = true
 if RUBY_VERSION < "1.9.2"
   $stderr.puts "Ruby 1.9.2 or later is required. (You are running: " + RUBY_VERSION + ")"


### PR DESCRIPTION
logstash runs with `Thread.abort_on_exception = true`, even though the default is false.

This means that all plugins should be developed with this set to true and, most importantly, the specs must run with `true` as well to ensure they'll work inside of Logstash.

Since all plugins' spec suites include the devutils spec_helper, I've added the flag there.