### PR TITLE
Add a plugin based input helper

### DIFF
--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -86,6 +86,19 @@ module LogStashHelper
     result
   end # def input
 
+  def plugin_input(plugin, &block)
+    queue = Queue.new
+
+    input_thread = Thread.new do
+      plugin.run(queue)
+    end
+    result = block.call(queue)
+
+    plugin.do_stop
+    input_thread.join
+    result
+  end
+
   def agent(&block)
 
     it("agent(#{caller[0].gsub(/ .*/, "")}) runs") do

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.17"
+  spec.version = "0.0.18"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"


### PR DESCRIPTION
This help out testing input plugins without the need of passing up a config and creating a pipeline.