### PR TITLE
force utf8 encoding for source files and reading in files

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -1,3 +1,6 @@
+Encoding.default_internal = Encoding::UTF_8
+Encoding.default_external = Encoding::UTF_8
+
 if ENV['COVERAGE']
   require 'simplecov'
   require 'coveralls'


### PR DESCRIPTION
We periodically run into issues where Logstash has explicit checks for encoding. At the same time, some of the source files are being encoded as ASCII. This is resulting in unnecessary runtime failures.