### PR TITLE
Add plain codec to mirror the fact that it is bundled in logstash

### DIFF
--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -37,6 +37,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "minitar" # GPL2|Ruby License
   spec.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
 
+  # Plain codec is required for `bundle exec rspec` in plugins gem as it is input/output default codec (declared in logstash-core/{in,out}puts/base.rb)
+  spec.add_runtime_dependency "logstash-codec-plain"
+
   # Should be removed as soon as the plugins are using insist by their
   # own, and not relying on being required by the spec helper.
   # (some plugins does it, some use insist throw spec_helper)


### PR DESCRIPTION
Found while cleaning up dependencies in a plugin that is not using codec => https://github.com/logstash-plugins/logstash-output-statsd/pull/25

@ph With seconds thoughts, IMHO it should maybe better go into logstash-plugin-core-api gemspec, no?
