### PR TITLE
Manually require the logstash-core gem to make sure all the jars are available when we run the tests in the plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.2.1
+ - require logstash-core gem manually to make all the jars available to the plugin unit tests

--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -12,6 +12,7 @@ if ENV['COVERAGE']
   end
 end
 
+require "logstash-core"
 require "logstash/logging"
 require "logstash/environment"
 require "logstash/devutils/rspec/logstash_helpers"

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.2.0"
+  spec.version = "1.2.1"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
Manually require the logstash-core gem to make sure all the jars are available when we run the tests in the plugins

This PR is needed to fix https://github.com/elastic/logstash/issues/6374