### PR TITLE
Respect `default_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.2.2
+ - Ensure the `default_type` is respected.
+
 ## 1.2.1
  - require logstash-core gem manually to make all the jars available to the plugin unit tests

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -35,7 +35,8 @@ module LogStashHelper
       let(:event) do
         sample_event = [sample_event] unless sample_event.is_a?(Array)
         next sample_event.collect do |e|
-          e = { "message" => e } if e.is_a?(String)
+          e = { 'message' => e } if e.is_a?(String)
+          e['type'] ||= default_type if default_type
           next LogStash::Event.new(e)
         end
       end

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.2.1"
+  spec.version = "1.2.2"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
`LogStashHelper` currently provides a `type` method which seems to be able to be used for setting a default `type` field for `LogStash::Event` objects. The `default_type` variable, however, is never actually read.