### PR TITLE
fix URL of log4j properties file to avoid MalformedURLException on Windows

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -23,7 +23,7 @@ Thread.abort_on_exception = true
 
 # set log4j configuration
 unless java.lang.System.getProperty("log4j.configurationFile")
-  log4j2_properties = "#{File.dirname(__FILE__)}/log4j2.properties"
+  log4j2_properties = "file://#{File.dirname(__FILE__)}/log4j2.properties"
   LogStash::Logging::Logger::initialize(log4j2_properties)
 end
 


### PR DESCRIPTION
On Windows, when trying to run specs using the devutils helper, the following exception is thrown:

    ERROR StatusLogger Invalid URL C:/jruby-9.1.7.0/lib/ruby/gems/shared/gems/logstash-devutils-1.2.1-java/lib/logstash/devutils/rspec/log4j2.properties
     java.net.MalformedURLException: unknown protocol: c
        at java.net.URL.<init>(URL.java:600)
        at java.net.URL.<init>(URL.java:490)
        at java.net.URL.<init>(URL.java:439)
        at java.net.URI.toURL(URI.java:1089)
        at org.apache.logging.log4j.core.config.ConfigurationFactory.getInputFromUri(ConfigurationFactory.java:299)
        at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:234)
        at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:433)
        at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:237)
        at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:157)
        at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:130)
        at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:100)
        at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:187)

I believe this is happening because the `C:` drive letter prefix is interpreted as the protocol in the URL. If you prefix with `file://`, it should work. I am not entirely sure how to test this, because I am not a Ruby expert and I am not sure how to set a system property while running `bundle exec`. This should be a harmless change for UNIX platforms, though.
