### PR TITLE
close pipeline after #sample helper and bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+ - Close pipeline after #sample helper - for compatibility with logstash-core 5.3
+
 ## 1.3.0
  - Temporary add more visibility into the pipeline to make the #sample method work
 

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -60,6 +60,11 @@ module LogStashHelper
         results.select { |e| !e.cancelled? }
       end
 
+      # starting at logstash-core 5.3 an initialized pipeline need to be closed
+      after do
+        pipeline.close if pipeline.respond_to?(:close)
+      end
+
       subject { results.length > 1 ? results : results.first }
 
       it("when processed", &block)

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.3.0"
+  spec.version = "1.3.1"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
For logstash-core 5.3 which requires the pipeline to be closed after initialization.

This change is backward compatible by checking if the `Pipeline#close` method exists.

Required for elastic/logstash/pull/6656