### PR TITLE
compatibility fixes for logstash 6.0 and ruby 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 1.3.3
+ - Make input function support different pipeline constructor signatures - for compatibility with logstash-core 6.0
+ - Make return of lambda used in input helpers explicit
+
 ## 1.3.2
- - Make sample function with multiple pipelines - for compatibility with logstash-core 6.0
+ - Make sample function support different pipeline constructor signatures - for compatibility with logstash-core 6.0
 
 ## 1.3.1
  - Close pipeline after #sample helper - for compatibility with logstash-core 5.3

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -72,7 +72,7 @@ module LogStashHelper
   end # def sample
 
   def input(config, &block)
-    pipeline = LogStash::Pipeline.new(config)
+    pipeline = new_pipeline_from_string(config)
     queue = Queue.new
 
     pipeline.instance_eval do
@@ -82,6 +82,10 @@ module LogStashHelper
       # output_func is now a method, call closure
       def output_func(event)
         @output_func.call(event)
+        # We want to return nil or [] since outputs aren't used here
+        # NOTE: In Ruby 1.9.x, Queue#<< returned nil, but in 2.x it returns the queue itself
+        # So we need to be explicit about the return
+        nil
       end
     end
 

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.3.2"
+  spec.version = "1.3.3"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
otherwise code that uses the input helper with post multiple pipelines logstash-core will see an exception due to the Pipeline constructor signature change