### PR TITLE
fix file url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.3.5
  - Fix spec helper method `input` generating an invalid `output_func` that returned `nil` instead of an array
+ - Remove spec helper log4j explicit initialization and rely on logstash-core default log4j initialization
 
 ## 1.3.4
  - Pin kramdown gem to support ruby 1.x syntax for LS 5.x

--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -24,7 +24,7 @@ Thread.abort_on_exception = true
 # set log4j configuration
 unless java.lang.System.getProperty("log4j.configurationFile")
   log4j2_properties = "#{File.dirname(__FILE__)}/log4j2.properties"
-  LogStash::Logging::Logger::initialize(log4j2_properties)
+  LogStash::Logging::Logger::initialize("file:///" + log4j2_properties)
 end
 
 $TESTING = true

--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -21,12 +21,6 @@ require "insist"
 
 Thread.abort_on_exception = true
 
-# set log4j configuration
-unless java.lang.System.getProperty("log4j.configurationFile")
-  log4j2_properties = "#{File.dirname(__FILE__)}/log4j2.properties"
-  LogStash::Logging::Logger::initialize("file:///" + log4j2_properties)
-end
-
 $TESTING = true
 if RUBY_VERSION < "1.9.2"
   $stderr.puts "Ruby 1.9.2 or later is required. (You are running: " + RUBY_VERSION + ")"


### PR DESCRIPTION
The path to the log4j properties file is missing the leading `file://` and on Windows it produces this exception
```
2017-08-25 17:56:47,566 main ERROR Invalid URL C:/Users/colin/dev/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-devutils-1.3.3 java/lib/logstash/devutils/rspec/log4j2.properties java.net.MalformedURLException: unknown protocol: c
```

Prefixing it is consistent with our strategy in logstash see https://github.com/elastic/logstash/blob/93f0f1d2fb3e7d6a1b8323f307741ac373e12ef5/logstash-core/lib/logstash/runner.rb#L244