### PR TITLE
BUG: Return empty array instead of nil from filter test util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.5
+ - Fix spec helper method `input` generating an invalid `output_func` that returned `nil` instead of an array
+
 ## 1.3.4
  - Pin kramdown gem to support ruby 1.x syntax for LS 5.x
 

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -85,7 +85,7 @@ module LogStashHelper
         # We want to return nil or [] since outputs aren't used here
         # NOTE: In Ruby 1.9.x, Queue#<< returned nil, but in 2.x it returns the queue itself
         # So we need to be explicit about the return
-        nil
+        []
       end
     end
 

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.3.4"
+  spec.version = "1.3.5"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
`output_func` always returns an array no matter what.  dev-utils behavior must be in line with production code here to fix builds like this one https://travis-ci.org/logstash-plugins/logstash-input-elasticsearch/jobs/284374623#L1137 (elasticsearch input is broken with LS master atm).

I caused this here https://github.com/elastic/logstash/pull/8446/files#diff-bc1e9ea81caa54ea0d56abf4415fdf00R524 accidentally because I couldn't find any specs that required the removed hack. Now I found them ...this should fix all cases though for LS pre and post that commit.