### PR TITLE
Fix 5.x tests while keeping support for Windows

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -21,6 +21,12 @@ require "insist"
 
 Thread.abort_on_exception = true
 
+# set log4j configuration
+unless java.lang.System.getProperty("log4j.configurationFile")
+  log4j2_properties = "#{File.dirname(__FILE__)}/log4j2.properties"
+  LogStash::Logging::Logger::initialize("file:///" + log4j2_properties)
+end
+
 $TESTING = true
 if RUBY_VERSION < "1.9.2"
   $stderr.puts "Ruby 1.9.2 or later is required. (You are running: " + RUBY_VERSION + ")"

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "1.3.5"
+  spec.version = "1.3.6"
   spec.licenses = ["Apache License (2.0)"]
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"


### PR DESCRIPTION
5.x still requires the log4j to be initialized here, for 6.x it is just redundant. 