### PR TITLE
Fix: support LS 6.3 + handle multiple run_with calls

### DIFF
--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -74,7 +74,7 @@ module LogStashHelper
         # flush makes sure to empty any buffered events in the filter
         pipeline.flush_filters(:final => true) { |flushed_event| results << flushed_event }
 
-        pipeline.test_read_client.processed_events
+        pipeline.filter_queue_client.processed_events
       end
 
       # starting at logstash-core 5.3 an initialized pipeline need to be closed


### PR DESCRIPTION
from within single example (not likely to be used but still)

we need a little trick on handling LS 6.3 compatibility in the `TestPipeline`.
should have been part of #79
