### PR TITLE
Fix: unwrap output and refactor test sink

### DIFF
--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.0.0"
+  spec.version = "2.0.1"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
the old way wasn't reliable in case of pipeline failures

this is now expected to be more robust at a cost of relying on some of
the native internals (which are available since LS 6.3 - our baseline)

discovered at https://github.com/logstash-plugins/logstash-input-elasticsearch/pull/118#issuecomment-595434716 ... [here's a failing build](https://travis-ci.org/logstash-plugins/logstash-input-elasticsearch/jobs/658751372#L587) these are expected to resolve