### PR TITLE
set helper pipeline workers to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+ - Set number of pipeline workers to 1 in helper pipelines to facilitate plugin testing
+
 ## 2.0.0
  - Reinvented helpers using Java pipeline, only LS >= 6.x (JRuby >= 9.1) is supported.
  - [BREAKING] changes:

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -52,6 +52,12 @@ module LogStashHelper
     deprecated "tags(#{tags.inspect}) - let(:default_tags) are not used"
   end
 
+  def default_pipeline_settings(hash = {})
+    settings = ::LogStash::SETTINGS.clone
+    settings.set_value("pipeline.workers", 1)
+    settings
+  end
+
   def sample(sample_event, &block)
     name = sample_event.is_a?(String) ? sample_event : LogStash::Json.dump(sample_event)
     name = name[0..50] + "..." if name.length > 50
@@ -144,7 +150,7 @@ module LogStashHelper
     new_pipeline(config_parts, pipeline_id)
   end
 
-  def new_pipeline(config_parts, pipeline_id = :main, settings = ::LogStash::SETTINGS.clone)
+  def new_pipeline(config_parts, pipeline_id = :main, settings = default_pipeline_settings())
     pipeline_config = LogStash::Config::PipelineConfig.new(LogStash::Config::Source::Local, pipeline_id, config_parts, settings)
     TestPipeline.new(pipeline_config)
   end

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.0.1"
+  spec.version = "2.0.2"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
this removes potential race conditions and makes testing logic
easier by removing concurrency from the filter+output pipeline stage