### PR TITLE
Add `events` method to QueueBatchDelegator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+ - Fix: add missing `events` method to QueuedBatchDelegator, which was causing test failures
+ after https://github.com/elastic/logstash/pull/11737 was committed.
+
 ## 2.0.2
  - Fix: add plain codec as runtime dependency for TestPipeline helper
 

--- a/lib/logstash/test_pipeline.rb
+++ b/lib/logstash/test_pipeline.rb
@@ -151,6 +151,13 @@ module LogStash
         @delegate.to_java.filtered_size
       end
 
+      def events
+        @delegate.events.tap do |events|
+          # filters out rogue (cancelled) events
+          @event_tracker.filtered_events events
+        end
+      end
+
       # @override void merge(IRubyObject event);
       def merge(event)
         @delegate.merge(event)

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.0.2"
+  spec.version = "2.0.3"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
After https://github.com/elastic/logstash/pull/11737 was committed, plugin unit tests
using `sample` targeted against branches with this change merged were failing due to the lack of
`events` method on the QueueBatchDelegator.

This commit adds an `events` method to fix the failing tests.