### PR TITLE
Fix: bundle resolution due added codec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec
 
 if Dir.exist?(logstash_path = ENV["LOGSTASH_PATH"])
   gem 'logstash-core', path: "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', path: "#{logstash_path}/logstash-core-plugin-api"
 end


### PR DESCRIPTION
since ccaaa22efcb51ec15825b8ee41011624ac7e159d (https://github.com/elastic/logstash-devutils/pull/83) we caused `bundle` resolution to fail as recent logstash-codec-plain needs
logstash-core-plugin-api which isn't published to RubyGems.org