### PR TITLE
Fix: avoid double registering filters in sample helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4
+ - Fix: avoid double registering filters on `sample` spec helper
+
 ## 2.0.3
  - Fix: add missing `events` method to QueuedBatchDelegator, which was causing test failures
  after https://github.com/elastic/logstash/pull/11737 was committed.

--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -67,8 +67,7 @@ module LogStashHelper
       end
 
       let(:results) do
-        pipeline.filters.each(&:register)
-
+        # Java pipeline (since 6.1) registers filters from start_workers
         pipeline.run_with(event)
 
         # flush makes sure to empty any buffered events in the filter

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.0.3"
+  spec.version = "2.0.4"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
This PR changes `sample` test helper do not explicitly call `filter.register`.
Filter registration is performed by the Java pipeline automatically and this leads to unexpected behavior for plugins that assume 'previous' state in `register` -> plugin under test behaving differently than within the context of LS.

---

at least since LS 6.1.0 filters get registered on worker startup:
https://github.com/elastic/logstash/blob/v6.1.0/logstash-core/lib/logstash/java_pipeline.rb#L667-L672

devutils requires `"logstash-core", ">= 6.3"` so it's safe to remove

resolves https://github.com/elastic/logstash-devutils/issues/77