### PR TITLE
remove logstash/pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.4
+ - Remove ruby pipeline dependency
+
 ## 2.0.4
  - Fix: avoid double registering filters on `sample` spec helper
 

--- a/lib/logstash/test_pipeline.rb
+++ b/lib/logstash/test_pipeline.rb
@@ -1,4 +1,3 @@
-require "logstash/pipeline"
 require "logstash/java_pipeline"
 
 module LogStash

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.0.4"
+  spec.version = "2.1.4"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
Fixed: https://github.com/elastic/logstash/issues/11236

This PR remove ruby pipeline dependency