### PR TITLE
shared specs: make interruptible input spec allowable lag configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+ - Add `allowed_lag` config for shared input interruptiblity spec
+
 ## 2.1.0
  - Remove ruby pipeline dependency
 

--- a/lib/logstash/devutils/rspec/shared_examples.rb
+++ b/lib/logstash/devutils/rspec/shared_examples.rb
@@ -1,6 +1,10 @@
 require 'rspec/wait'
 
 RSpec.shared_examples "an interruptible input plugin" do
+  # why 3? 2 is not enough, 4 is too much..
+  # a plugin that is known to be slower can override
+  let(:allowed_lag) { 3 }
+
   describe "#stop" do
     let(:queue) { SizedQueue.new(20) }
     subject { described_class.new(config) }
@@ -14,8 +18,7 @@ RSpec.shared_examples "an interruptible input plugin" do
       expect(plugin_thread).to be_alive
       # now let's actually stop the plugin
       subject.do_stop
-      # why 3? 2 is not enough, 4 is too much..
-      wait(3).for { plugin_thread }.to_not be_alive
+      wait(allowed_lag).for { plugin_thread }.to_not be_alive
     end
   end
 end

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.1.0"
+  spec.version = "2.2.0"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
The S3 input is having a problem where the shared input shutdown spec is consistently failing in CI on Logstash 6.x because that plugin takes ~3.1s to fully shut down.

This PR introduces an `allowed_lag` (default: 3) to replace the hard-coded 3 second value to allow plugins to declare how long they are willing to wait in validating the plugin's interruptibility.

To use it, add a block to your rspec `it_behaves_like` block and define your own `allowed_lag`:

~~~ ruby
it_behaves_like "an interruptible input plugin" do
  let(:allowed_lag) { 4 } if LOGSTASH_VERSION.split('.').first.to_i <= 6
end
~~~