### PR TITLE
rake tasks: use our own vendor and publish rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,3 @@
 raise "only JRuby is supported" unless defined? JRUBY_VERSION
 require 'bundler/gem_tasks'
+require 'logstash/devutils/rake'


### PR DESCRIPTION
This plugin provides rake tasks for preparing (`vendor`) and publishing release artifacts (`publish`) that are used by our plugiuns.

These tasks can be included in our own `Rakefile`, which allows this library to be published with the same toolchain.