### PR TITLE
Feat: shared test (spec) task for all!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.0
+ - Feat: shared test (spec) task for all! [#96](https://github.com/elastic/logstash-devutils/pull/96)
+
 ## 2.3.0
  - Introduce `be_a_logstash_timestamp_equivalent_to` RSpec matcher to compare LogStash::Timestamp [#99](https://github.com/elastic/logstash-devutils/pull/99)
 

--- a/lib/logstash/devutils/rake.rb
+++ b/lib/logstash/devutils/rake.rb
@@ -1,3 +1,4 @@
 raise "Only JRuby is supported at this time." unless RUBY_PLATFORM == "java"
 load "logstash/devutils/rake/publish.rake"
 load "logstash/devutils/rake/vendor.rake"
+load "logstash/devutils/rake/test.rake"

--- a/lib/logstash/devutils/rake/test.rake
+++ b/lib/logstash/devutils/rake/test.rake
@@ -5,14 +5,13 @@ rescue LoadError
 end
 
 desc "Run tests including Java tests (if any)"
-task :test do
-  gradlew = File.join(Dir.pwd, 'gradlew')
-  sh "#{gradlew} --no-daemon test" if File.exist?(gradlew)
-
-  # Gradle assumes tests need a clean built so it will `clean` as part
-  # of the `test` task -> any built .jar or copyied files get deleted
-  # thus this isn't a `task :test => :vendor` dependency.
-  Rake::Task[:vendor].invoke
-
-  Rake::Task[:spec].invoke
+task :test => [ 'test:java', 'test:ruby' ]
+namespace :test do
+  task :java do
+    gradlew = File.join(Dir.pwd, 'gradlew')
+    sh "#{gradlew} --no-daemon test" if File.exist?(gradlew)
+  end
+  task :ruby => :vendor do
+    Rake::Task[:spec].invoke
+  end
 end

--- a/lib/logstash/devutils/rake/test.rake
+++ b/lib/logstash/devutils/rake/test.rake
@@ -7,7 +7,7 @@ end
 desc "Run tests including Java tests (if any)"
 task :test do
   gradlew = File.join(Dir.pwd, 'gradlew')
-  sh "#{gradlew} --no-daemon test" if File.exist?('gradlew')
+  sh "#{gradlew} --no-daemon test" if File.exist?(gradlew)
 
   # Gradle assumes tests need a clean built so it will `clean` as part
   # of the `test` task -> any built .jar or copyied files get deleted

--- a/lib/logstash/devutils/rake/test.rake
+++ b/lib/logstash/devutils/rake/test.rake
@@ -5,7 +5,14 @@ rescue LoadError
 end
 
 desc "Run tests including Java tests (if any)"
-task :test => :vendor do
-  sh './gradlew test' if File.exist?('./gradlew')
+task :test do
+  gradlew = File.join(Dir.pwd, 'gradlew')
+  sh "#{gradlew} --no-daemon test" if File.exist?('gradlew')
+
+  # Gradle assumes tests need a clean built so it will `clean` as part
+  # of the `test` task -> any built .jar or copyied files get deleted
+  # thus this isn't a `task :test => :vendor` dependency.
+  Rake::Task[:vendor].invoke
+
   Rake::Task[:spec].invoke
 end

--- a/lib/logstash/devutils/rake/test.rake
+++ b/lib/logstash/devutils/rake/test.rake
@@ -1,0 +1,11 @@
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec) # default glob: 'spec/**{,/*/**}/*_spec.rb'
+rescue LoadError
+end
+
+desc "Run tests including Java tests (if any)"
+task :test => :vendor do
+  sh './gradlew test' if File.exist?('./gradlew')
+  Rake::Task[:spec].invoke
+end

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.3.0"
+  spec.version = "2.4.0"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
adds a `rake spec` task to effectively run `rspec`,
also introduces a test task convention to run Java tests (if available) followed by a spec run

*NOTE: both `spec` and `gradle test` invocations will exit the Rake process with non-zero when failing*
The vendor task is already [present](https://github.com/elastic/logstash-devutils/blob/master/lib/logstash/devutils/rake/vendor.rake#L152), plugins are usually expected to override (e.g. doing a `./gradlew clean vendor`)

The default `rake test` task is meant to be [leveraged by .ci](https://github.com/logstash-plugins/.ci/pull/36/files#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR8) (in a follow-up https://github.com/logstash-plugins/.ci/pull/36)

---

NOTE: has been tested with useragent filter, date filter and DLQ input (which all have Java tests).