### PR TITLE
sample spec helper: default to validating output (not mutated input)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+ - Fixed `LogStashHelpers#sample` to work with pipelines whose filters add, clone, and cancel events.
+
 ## 2.2.0
  - Add `allowed_lag` config for shared input interruptiblity spec
 

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.2.0"
+  spec.version = "2.2.1"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
The queue of processed events is not a reliable record of the results of a
pipeline's processing. It fails to account for events that are created by
filters (such as `split`, `clone`, some uses of the `ruby` filter, etc.),
contains events that have been cancelled and were not routed to outputs,
and relies on the current implementation detail of the queue holding
references to the events that are later mutated.

By default, the `sample` helper should validate the _actual_ result of the
provided event(s) to the pipeline, as received by the outputs.

In order to reduce the risk of one of our plugins somehow _needing_ to rely on
queue state for validation cascading to a reversion of this change, we also
provide an option for plugins to explicitly opt to validate the queue
(supply `validation_source: :queue` to the `sample` helper).