### PR TITLE
Add matcher to compare LogStash::Timestamp across different versions of LogStash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+ - Introduce `be_a_logstash_timestamp_equivalent_to` RSpec matcher to compare LogStash::Timestamp [#99](https://github.com/elastic/logstash-devutils/pull/99)
+
 ## 2.2.1
  - Fixed `LogStashHelpers#sample` to work with pipelines whose filters add, clone, and cancel events.
 
@@ -25,15 +28,15 @@
  - [BREAKING] changes:
    * `plugin_input` helper no longer works - simply fails with a not implemented error
    * `type` and `tags` helpers have no effect - they will print a deprecation warning
-   * using gem **insist** is discouraged and has to be pulled in manually 
+   * using gem **insist** is discouraged and has to be pulled in manually
      (in *plugin.gemspec* `add_development_dependency 'insist'` and `require "insist"`)
    * shared examples need to be explicitly required, as they are not re-used that much
      (in spec_helper.rb `require "logstash/devutils/rspec/shared_examples"'`)
    * `input` helper now yields a Queue-like collection (with `Queue#pop` blocking semantics)
-     with a default timeout polling mechanism to guard against potential dead-locks 
+     with a default timeout polling mechanism to guard against potential dead-locks
 
 ## 1.3.6
- - Revert the removal (e.g. add back) of the log4j spec helper. It is still needed for 5.x builds. 
+ - Revert the removal (e.g. add back) of the log4j spec helper. It is still needed for 5.x builds.
 
 ## 1.3.5
  - Fix spec helper method `input` generating an invalid `output_func` that returned `nil` instead of an array

--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -38,6 +38,16 @@ else
   LogStash::Logging::Logger::configure_logging('ERROR')
 end
 
+RSpec::Matchers.define :be_a_logstash_timestamp_equivalent_to do |expected|
+  # use the Timestamp compare to avoid suffering of precision loss of time format
+  expected = LogStash::Timestamp.new(expected) unless expected.kind_of?(LogStash::Timestamp)
+  description { "be a LogStash::Timestamp equivalent to #{expected}" }
+
+  match do |actual|
+    actual.kind_of?(LogStash::Timestamp) && actual == expected
+  end
+end
+
 RSpec.configure do |config|
   # for now both include and extend are required because the newly refactored "input" helper method need to be visible in a "it" block
   # and this is only possible by calling include on LogStashHelper
@@ -57,4 +67,3 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = :random
 end
-

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.2.1"
+  spec.version = "2.3.0"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Introduce `be_a_logstash_timestamp_equivalent_to` RSpec matcher to compare LogStash::Timestamp

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
This commit adds a new shared matcher named `be_a_logstash_timestamp_equivalent_to` to stable compare Logstash's Timestamps. With introduction of nanosecond timestamp precision the compare based on string equality of timestamp is not stable across different versions of Logstash.

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
The developer of plugins must use this matcher to compare Timestamp equality in expectations

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Create the gem and check it's usable in the expected circumstances

## How to test this PR locally
- checkout this branch
- in a checkout of `filter-date` or `integration-jdbc` that embeds the matcher, comment the matcher
- in `Gemfile` of that dependent plugin add: `gem "logstash-devutils", :path => "/home/andrea/workspace/logstash_plugins/logstash-devutils"`
- in the folder of the dependent plugin install and execute the rspec, for example for date filter:
  - `bundle intall`
  - `bundle exec rspec spec/filters/date_spec.rb`

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #98 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
