### PR TITLE
bump kramdown dependency to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.0
+ - Bumped kramdown dependency to "~> 2"
+
 ## 2.4.0
  - Feat: shared test (spec) task for all! [#96](https://github.com/elastic/logstash-devutils/pull/96)
 

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "2.4.0"
+  spec.version = "2.5.0"
   spec.license = "Apache-2.0"
   spec.authors = ["Elastic"]
   spec.email = "info@elastic.co"
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   # Some plugins are (still) using insist by their own, but we no longer force this dependency on others.
   #spec.add_runtime_dependency "insist" # (Apache 2.0 license)
-  spec.add_runtime_dependency "kramdown", '1.14.0'
+  spec.add_runtime_dependency "kramdown", '~> 2'
   spec.add_runtime_dependency "stud", " >= 0.0.20"
   spec.add_runtime_dependency "fivemat"
   spec.add_runtime_dependency "logstash-codec-plain"


### PR DESCRIPTION
All breaking changes in 2.0 don't seem to affect us: https://github.com/gettalong/kramdown/commit/2e9ee6cd3068e4c9e39bbc9b23350d141a2ed972#diff-d21f7e0f734aa84f3eb0ff01b4a62d738b94382b61a14d83c16e6ab776926772R10-R16